### PR TITLE
Emit the minimum number of `(void)` casts that still silences `-Wunused-parameter`

### DIFF
--- a/src/Language/Smudge/Backends/CStatic.hs
+++ b/src/Language/Smudge/Backends/CStatic.hs
@@ -287,7 +287,7 @@ convertIR dodec dodef (aliases, ir) =
                   array_index_e = (#:) (EPostfixExpression (convertVar a) LEFTSQUARE (fromList [(#:) (convertVar i) (:#)]) RIGHTSQUARE) (:#)
 
         convertVoidedVar :: Var (FullyQualAndEvent Identifier) -> CastExpression
-        convertVoidedVar (Var x)     = (TCastExpression LEFTPAREN (TypeName (SimpleList (Left VOID) Nothing) Nothing) RIGHTPAREN (UCastExpression $ (#:) (fullQual x) (:#)))
+        convertVoidedVar v = TCastExpression LEFTPAREN (TypeName (SimpleList (Left VOID) Nothing) Nothing) RIGHTPAREN ((#:) (convertVar v) (:#))
 
         convertVar :: Var (FullyQualAndEvent Identifier) -> PostfixExpression
         convertVar (Var x)     = (#:) (fullQual x) (:#)


### PR DESCRIPTION
This limits the number of `(void)` casts by enumerating the free variables in the body of a function definition, and only emitting casts for formal parameters that are not in that set.