### PR TITLE
Derive CPU and platform from ghc -info

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -43,9 +43,9 @@ test_script:
 - mingw32-make package examples doc STACK_FLAGS="--no-terminal"
 
 artifacts:
-- path: smudge-*-windows.zip
+- path: smudge_*_*.zip
   name: Smudge Archive
-- path: smudge-*-windows.exe
+- path: smudge_*_*.exe
   name: Smudge Installer
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ deploy:
   api_key:
     secure: c/Xo3n9gmvI7l23+/fNuuuiGATJSTmZkSEKhmNO4jEhBkIqV3eEectSL/3SJSMkGzpe42kisgQXJzXDjuPvPmjz+a4pkKzBfS9qAaKO/299dP4f4Kb7DhaTy3s7OI6a+8xaaWsa0wytkHdLlbCMrqHfPdoa6IG8Cir+WlC2TK+IJIElTrH4y0eAKAlsoxy8qeV6FX8G9JruU1JWXF7UUELXwiYVPXXS0kIX9gZ8hRTxgilDrgFRIah9NvEOg20W2OEH5IXKU4d/xt8/xATr5IQh5kGLUKUUKJWORw71TTDszqheQNiLfeoRcb3Q2VVa84+7AhpQMLsNCQVcnlZLiYeNqR55E7Z0YjBOcFS6msRRjRKd2eU0bxBadLKNH+VHBY8UCGKr5GwEFFI3ECDiDecxQOidj+CJ6Y2DMxS3MjeXQRA9U4eLsStlKmP7yj4UuDfYAuHl39TbHxlRQO7Ra9vD5ev4dIasET/QpoH4rO9R0B9byriUwjGcqdLrJ6VHJNcHlTphMClhsx2ywT55DIKxMGuuvEoJe0yOWYu2xTGghSuSCxyv1kf5m9p4u0F1fuPf3FC2A7dPXH+wHtPbcBMZYM3RVB085Kx69MOxcNqOVDGbYwWZkZmgpRFPAfj+sF9nbYRyq+kddsx/j/Zi+dCK6JCxGzVsAtapKVwPHP20=
   file_glob: true
-  file: smudge-*-linux.*
+  file: smudge_*_*.*
   skip_cleanup: true
   on:
     repo: smudgelang/smudge

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,34 @@
 HSFILES=$(wildcard *.hs) $(wildcard app/*.hs) $(wildcard src/*/*.hs) $(wildcard src/*/*/*.hs) $(wildcard src/*/*/*/*.hs)
 
+CPU_PLAT_RAW=$(shell ghc -e "(\(Just p) -> p) $$ lookup "'"'"Target platform"'"'" $$(ghc --info)" | tr -d \")
+CPU_RAW=$(shell cut -d "-" -f 1 <<<"$(CPU_PLAT_RAW)")
+CPU_x86_64=amd64
+CPU_i386=i386
+TARGET_CPU=$(CPU_$(CPU_RAW))
+PLAT_RAW=$(shell cut -d "-" -f 2,3 <<<"$(CPU_PLAT_RAW)")
+PLAT_unknown-linux=linux
+PLAT_linux-gnu=linux
+PLAT_unknown-mingw32=windows
+PLAT_w64-mingw32=windows
+TARGET_PLATFORM=$(PLAT_$(PLAT_RAW))
+
 ifeq ($(OS),Windows_NT)
 SMUDGE_EXE=smudge.exe
-PLATFORM=windows
 /=\\
 PKGEXT=zip exe
 RC_FILE=$(SMUDGE_BUILD_DIR)/Properties.o
 CABAL_FLAGS+=--ghc-options $(RC_FILE)
 else
 SMUDGE_EXE=smudge
-PLATFORM=linux
 /=/
 PKGEXT=tgz deb
-DEBDIR=debian/smudge-$(SMUDGE_VERSION)-linux
+DEBDIR=debian/$(PACKAGE)_$(SMUDGE_VERSION)-$(TARGET_PLATFORM)_$(TARGET_CPU)
 endif
+
 define cabal_query
 $(shell grep "^$(1):" smudge.cabal | cut -d ':' -f 1 --complement | sed -e 's/^\s*//' -e 's/\s*$$//')
 endef
+PACKAGE=smudge
 SMUDGE_BUILD_DIR_RAW=$(shell stack path --local-install-root)
 SMUDGE_BUILD_DIR=$(subst \,/,$(SMUDGE_BUILD_DIR_RAW))
 SMUDGE_RELEASE_SUBDIR=smudge
@@ -101,10 +113,10 @@ stage: build docs/tutorial/tutorial.pdf
 	cp LICENSE $(SMUDGE_RELEASE_STAGE_DIR)
 	cp README.md $(SMUDGE_RELEASE_STAGE_DIR)
 
-package: $(foreach EXT,$(PKGEXT),smudge-$(SMUDGE_VERSION)-$(PLATFORM).$(EXT))
+package: $(foreach EXT,$(PKGEXT),$(PACKAGE)_$(SMUDGE_VERSION)-$(TARGET_PLATFORM)_$(TARGET_CPU).$(EXT))
 
-zip: smudge-$(SMUDGE_VERSION)-$(PLATFORM).zip
-smudge-$(SMUDGE_VERSION)-$(PLATFORM).zip: stage
+zip: $(PACKAGE)_$(SMUDGE_VERSION)-$(TARGET_PLATFORM)_$(TARGET_CPU).zip
+$(PACKAGE)_$(SMUDGE_VERSION)-$(TARGET_PLATFORM)_$(TARGET_CPU).zip: stage
 	cd $(SMUDGE_BUILD_DIR) && \
 	if type zip >/dev/null 2>&1; then \
 	    zip -r $@ $(SMUDGE_RELEASE_SUBDIR); \
@@ -122,19 +134,19 @@ $(SMUDGE_BUILD_DIR)/setup.iss: setup.iss.in smudge.cabal
 	@echo $(POUND)define MySetupDir     \"$(SMUDGE_RELEASE_STAGE_DIR)\" >>$@
 	cat $< >>$@
 
-exe: smudge-$(SMUDGE_VERSION)-$(PLATFORM).exe
-smudge-$(SMUDGE_VERSION)-windows.exe: $(SMUDGE_BUILD_DIR)/setup.iss stage
+exe: $(PACKAGE)_$(SMUDGE_VERSION)-$(TARGET_PLATFORM)_$(TARGET_CPU).exe
+$(PACKAGE)_$(SMUDGE_VERSION)-windows_$(TARGET_CPU).exe: $(SMUDGE_BUILD_DIR)/setup.iss stage
 	ISCC /Q $(SMUDGE_BUILD_DIR_RAW)\setup.iss
 	mv $(SMUDGE_BUILD_DIR)/$@ .
 
-tgz: smudge-$(SMUDGE_VERSION)-$(PLATFORM).tgz
-smudge-$(SMUDGE_VERSION)-linux.tgz: stage
+tgz: $(PACKAGE)_$(SMUDGE_VERSION)-$(TARGET_PLATFORM)_$(TARGET_CPU).tgz
+$(PACKAGE)_$(SMUDGE_VERSION)-linux_$(TARGET_CPU).tgz: stage
 	cd $(SMUDGE_BUILD_DIR) && \
 	fakeroot tar -czf $@ $(SMUDGE_RELEASE_SUBDIR)
 	mv $(SMUDGE_BUILD_DIR)/$@ .
 
-deb: smudge-$(SMUDGE_VERSION)-$(PLATFORM).deb
-smudge-$(SMUDGE_VERSION)-linux.deb: stage
+deb: $(PACKAGE)_$(SMUDGE_VERSION)-$(TARGET_PLATFORM)_$(TARGET_CPU).deb
+$(PACKAGE)_$(SMUDGE_VERSION)-linux_$(TARGET_CPU).deb: stage
 	mkdir -p $(DEBDIR)/DEBIAN
 	mkdir -p $(DEBDIR)/usr/bin
 	mkdir -p $(DEBDIR)/usr/share/doc/smudge/
@@ -146,7 +158,7 @@ smudge-$(SMUDGE_VERSION)-linux.deb: stage
 	# Note: the copyright file duplicates info from LICENSE.
 	cp debian/copyright $(DEBDIR)/usr/share/doc/smudge/
 	chmod 755 $(DEBDIR)/usr/bin/smudge
-	sed -e "s/__VERSION__/$(SMUDGE_VERSION)/g" -e "s/__ARCH__/`dpkg --print-architecture`/g" debian/control > $(DEBDIR)/DEBIAN/control
+	sed -e "s/__VERSION__/$(SMUDGE_VERSION)-linux/g" -e "s/__ARCH__/$(TARGET_CPU)/g" debian/control > $(DEBDIR)/DEBIAN/control
 	fakeroot dpkg --build $(DEBDIR)
 	mv $(DEBDIR).deb . # Whew, puns
 


### PR DESCRIPTION
After dumpster-diving inside Dpkg::Arch::get_raw_host_arch, it seems that Debian
CPUs derive from a table often found in /usr/share/dpkg/cputable Since that
isn't available on Windows, instead here is an expedient approximation that can
be used on both.